### PR TITLE
estrela em unicode; remoção do bug do pulo; remoção da cor ao final

### DIFF
--- a/chrisrmas-tree.rb
+++ b/chrisrmas-tree.rb
@@ -8,6 +8,7 @@ def draw
   puts_star
   turn_on_light(tree)
   puts colorize "Feliz Natal!".center(WIDTH), :red
+  puts "\e[0m"
 end
 
 
@@ -18,7 +19,7 @@ def turn_on_light(tree)
 end
 
 def puts_star  
-  puts colorize "★".center(WIDTH), :yellow
+  puts colorize "\u2605".center(WIDTH), :yellow
 end
 
 def blink
@@ -30,7 +31,7 @@ def colorize(string, color)
 end
 
 while true
+  system('clear')
   draw
   sleep(1)
-  system('clear')
 end


### PR DESCRIPTION
No meu PC dava erro ao executar por causa da estrela:

```
chrisrmas-tree.rb:21: invalid multibyte char (US-ASCII)
chrisrmas-tree.rb:21: invalid multibyte char (US-ASCII)
chrisrmas-tree.rb:21: syntax error, unexpected $end, expecting keyword_end
  puts colorize "★".center(WIDTH), :yellow
                   ^
```

Se tivesse algo na tela, árvore subia, porque limpava a tela somente ao final.
Ao encerra a execução, o console continuava colorido.
